### PR TITLE
feat(prisma): add backtest stats fields to StrategyHealthSnapshot

### DIFF
--- a/prisma/migrations/20260518100000_strategyhealthsnapshot_backtest_fields/migration.sql
+++ b/prisma/migrations/20260518100000_strategyhealthsnapshot_backtest_fields/migration.sql
@@ -1,0 +1,34 @@
+-- Migration: Add backtest baseline stats fields to StrategyHealthSnapshot
+-- These fields enable the engine's SignalDegradationObserver to compute
+-- per-strategy z-score degradation against real backtest baselines.
+-- All columns are nullable so legacy rows are unaffected.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'StrategyHealthSnapshot' AND column_name = 'backtestHitRate'
+  ) THEN
+    ALTER TABLE "StrategyHealthSnapshot" ADD COLUMN "backtestHitRate" DOUBLE PRECISION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'StrategyHealthSnapshot' AND column_name = 'backtestHitRateStdDev'
+  ) THEN
+    ALTER TABLE "StrategyHealthSnapshot" ADD COLUMN "backtestHitRateStdDev" DOUBLE PRECISION;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'StrategyHealthSnapshot' AND column_name = 'backtestExpectancyStdDev'
+  ) THEN
+    ALTER TABLE "StrategyHealthSnapshot" ADD COLUMN "backtestExpectancyStdDev" DOUBLE PRECISION;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5419,6 +5419,9 @@ model StrategyHealthSnapshot {
   windowCumulativePnlAmt   Decimal? @db.Decimal(20, 2)
 
   backtestExpectancy       Decimal? @db.Decimal(20, 6)
+  backtestHitRate          Float?
+  backtestHitRateStdDev    Float?
+  backtestExpectancyStdDev Float?
   divergenceZScore         Decimal? @db.Decimal(10, 6)
   divergenceAlertActive    Boolean  @default(false)
 

--- a/src/Account.ts
+++ b/src/Account.ts
@@ -456,6 +456,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -1926,6 +1929,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -1956,6 +1968,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2314,6 +2329,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3064,6 +3082,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3808,6 +3829,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4956,6 +4980,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -4986,6 +5019,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5344,6 +5380,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6094,6 +6133,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7405,6 +7447,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -7435,6 +7486,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7793,6 +7847,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8543,6 +8600,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/AccountLinkingRequest.ts
+++ b/src/AccountLinkingRequest.ts
@@ -488,6 +488,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -1987,6 +1990,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -2017,6 +2029,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2375,6 +2390,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3082,6 +3100,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3826,6 +3847,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5005,6 +5029,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -5035,6 +5068,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5393,6 +5429,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6100,6 +6139,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7439,6 +7481,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -7469,6 +7520,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7827,6 +7881,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8534,6 +8591,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/AccountRiskMetrics.ts
+++ b/src/AccountRiskMetrics.ts
@@ -803,6 +803,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2842,6 +2845,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -2872,6 +2884,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3745,6 +3760,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4586,6 +4604,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6295,6 +6316,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -6325,6 +6355,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7198,6 +7231,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -9067,6 +9103,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -9097,6 +9142,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -9970,6 +10018,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/Alert.ts
+++ b/src/Alert.ts
@@ -617,6 +617,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2653,6 +2656,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -2683,6 +2695,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3554,6 +3569,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4395,6 +4413,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6107,6 +6128,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -6137,6 +6167,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7008,6 +7041,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8883,6 +8919,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -8913,6 +8958,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -9784,6 +9832,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/Allocation.ts
+++ b/src/Allocation.ts
@@ -637,6 +637,9 @@ import { assertValidAllocation } from './validators/allocation-validator';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2689,6 +2692,15 @@ import { assertValidAllocation } from './validators/allocation-validator';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -2719,6 +2731,9 @@ import { assertValidAllocation } from './validators/allocation-validator';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3605,6 +3620,9 @@ import { assertValidAllocation } from './validators/allocation-validator';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4446,6 +4464,9 @@ import { assertValidAllocation } from './validators/allocation-validator';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6168,6 +6189,15 @@ import { assertValidAllocation } from './validators/allocation-validator';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -6198,6 +6228,9 @@ import { assertValidAllocation } from './validators/allocation-validator';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7084,6 +7117,9 @@ import { assertValidAllocation } from './validators/allocation-validator';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8969,6 +9005,15 @@ import { assertValidAllocation } from './validators/allocation-validator';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -8999,6 +9044,9 @@ import { assertValidAllocation } from './validators/allocation-validator';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -9885,6 +9933,9 @@ import { assertValidAllocation } from './validators/allocation-validator';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/AlpacaAccount.ts
+++ b/src/AlpacaAccount.ts
@@ -874,6 +874,9 @@ import { logger } from './utils/logger';
         windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
         windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
         backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+        backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+        backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+        backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
         divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
         divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
         averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3661,6 +3664,15 @@ import { logger } from './utils/logger';
         backtestExpectancy: item.backtestExpectancy !== undefined ? {
             set: item.backtestExpectancy
           } : undefined,
+        backtestHitRate: item.backtestHitRate !== undefined ? {
+            set: item.backtestHitRate
+          } : undefined,
+        backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+            set: item.backtestHitRateStdDev
+          } : undefined,
+        backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+            set: item.backtestExpectancyStdDev
+          } : undefined,
         divergenceZScore: item.divergenceZScore !== undefined ? {
             set: item.divergenceZScore
           } : undefined,
@@ -3691,6 +3703,9 @@ import { logger } from './utils/logger';
         windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
         windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
         backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+        backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+        backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+        backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
         divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
         divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
         averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6291,6 +6306,9 @@ import { logger } from './utils/logger';
         windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
         windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
         backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+        backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+        backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+        backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
         divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
         divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
         averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8740,6 +8758,15 @@ import { logger } from './utils/logger';
         backtestExpectancy: item.backtestExpectancy !== undefined ? {
             set: item.backtestExpectancy
           } : undefined,
+        backtestHitRate: item.backtestHitRate !== undefined ? {
+            set: item.backtestHitRate
+          } : undefined,
+        backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+            set: item.backtestHitRateStdDev
+          } : undefined,
+        backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+            set: item.backtestExpectancyStdDev
+          } : undefined,
         divergenceZScore: item.divergenceZScore !== undefined ? {
             set: item.divergenceZScore
           } : undefined,
@@ -8770,6 +8797,9 @@ import { logger } from './utils/logger';
         windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
         windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
         backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+        backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+        backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+        backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
         divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
         divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
         averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -12756,6 +12786,15 @@ import { logger } from './utils/logger';
         backtestExpectancy: item.backtestExpectancy !== undefined ? {
             set: item.backtestExpectancy
           } : undefined,
+        backtestHitRate: item.backtestHitRate !== undefined ? {
+            set: item.backtestHitRate
+          } : undefined,
+        backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+            set: item.backtestHitRateStdDev
+          } : undefined,
+        backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+            set: item.backtestExpectancyStdDev
+          } : undefined,
         divergenceZScore: item.divergenceZScore !== undefined ? {
             set: item.divergenceZScore
           } : undefined,
@@ -12786,6 +12825,9 @@ import { logger } from './utils/logger';
         windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
         windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
         backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+        backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+        backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+        backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
         divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
         divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
         averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -453,6 +453,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -1927,6 +1930,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -1957,6 +1969,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2315,6 +2330,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3076,6 +3094,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3820,6 +3841,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4979,6 +5003,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -5009,6 +5042,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5367,6 +5403,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6128,6 +6167,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7450,6 +7492,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -7480,6 +7531,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7838,6 +7892,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8599,6 +8656,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/Customer.ts
+++ b/src/Customer.ts
@@ -645,6 +645,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2098,6 +2101,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -2128,6 +2140,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2486,6 +2501,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3231,6 +3249,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3975,6 +3996,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5109,6 +5133,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -5139,6 +5172,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5497,6 +5533,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6242,6 +6281,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7536,6 +7578,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -7566,6 +7617,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7924,6 +7978,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8669,6 +8726,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/LinkedProvider.ts
+++ b/src/LinkedProvider.ts
@@ -480,6 +480,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -1970,6 +1973,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -2000,6 +2012,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2358,6 +2373,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3084,6 +3102,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3828,6 +3849,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5002,6 +5026,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -5032,6 +5065,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5390,6 +5426,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6116,6 +6155,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7450,6 +7492,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -7480,6 +7531,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7838,6 +7892,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8564,6 +8621,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/LlmConfiguration.ts
+++ b/src/LlmConfiguration.ts
@@ -488,6 +488,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2010,6 +2013,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -2040,6 +2052,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2398,6 +2413,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3099,6 +3117,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3843,6 +3864,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5039,6 +5063,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -5069,6 +5102,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5427,6 +5463,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6128,6 +6167,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7487,6 +7529,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -7517,6 +7568,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7875,6 +7929,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8576,6 +8633,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/PolicyOverlay.ts
+++ b/src/PolicyOverlay.ts
@@ -388,6 +388,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -777,6 +780,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -1311,6 +1317,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2586,6 +2595,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -2616,6 +2634,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2899,6 +2920,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3228,6 +3252,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4155,6 +4182,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -4185,6 +4221,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4480,6 +4519,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5471,6 +5513,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6540,6 +6585,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -6570,6 +6624,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6865,6 +6922,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7853,6 +7913,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8530,6 +8593,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8919,6 +8985,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -9453,6 +9522,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -10402,6 +10474,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -10432,6 +10513,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -10715,6 +10799,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -11044,6 +11131,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -11971,6 +12061,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -12001,6 +12100,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -12296,6 +12398,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -13287,6 +13392,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -14356,6 +14464,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -14386,6 +14503,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -14681,6 +14801,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -15669,6 +15792,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -16781,6 +16907,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -16811,6 +16946,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -17094,6 +17232,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -17423,6 +17564,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -18350,6 +18494,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -18380,6 +18533,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -18675,6 +18831,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -19666,6 +19825,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -20735,6 +20897,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -20765,6 +20936,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -21060,6 +21234,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -22048,6 +22225,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/RiskEscalationEvent.ts
+++ b/src/RiskEscalationEvent.ts
@@ -663,6 +663,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3299,6 +3302,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -3329,6 +3341,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3893,6 +3908,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7165,6 +7183,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -9476,6 +9497,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -9506,6 +9536,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -10070,6 +10103,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -14422,6 +14458,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -14452,6 +14497,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -15016,6 +15064,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -452,6 +452,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -1926,6 +1929,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -1956,6 +1968,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2314,6 +2329,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3076,6 +3094,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3820,6 +3841,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4980,6 +5004,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -5010,6 +5043,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5368,6 +5404,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6130,6 +6169,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7453,6 +7495,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -7483,6 +7534,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7841,6 +7895,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8603,6 +8660,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/StrategyHealthSnapshot.ts
+++ b/src/StrategyHealthSnapshot.ts
@@ -191,6 +191,9 @@ import { logger } from './utils/logger';
   windowMaxDrawdownPct
   windowCumulativePnlAmt
   backtestExpectancy
+  backtestHitRate
+  backtestHitRateStdDev
+  backtestExpectancyStdDev
   divergenceZScore
   divergenceAlertActive
   averageConfidence
@@ -257,6 +260,9 @@ import { logger } from './utils/logger';
   windowMaxDrawdownPct: props.windowMaxDrawdownPct !== undefined ? props.windowMaxDrawdownPct : undefined,
   windowCumulativePnlAmt: props.windowCumulativePnlAmt !== undefined ? props.windowCumulativePnlAmt : undefined,
   backtestExpectancy: props.backtestExpectancy !== undefined ? props.backtestExpectancy : undefined,
+  backtestHitRate: props.backtestHitRate !== undefined ? props.backtestHitRate : undefined,
+  backtestHitRateStdDev: props.backtestHitRateStdDev !== undefined ? props.backtestHitRateStdDev : undefined,
+  backtestExpectancyStdDev: props.backtestExpectancyStdDev !== undefined ? props.backtestExpectancyStdDev : undefined,
   divergenceZScore: props.divergenceZScore !== undefined ? props.divergenceZScore : undefined,
   divergenceAlertActive: props.divergenceAlertActive !== undefined ? props.divergenceAlertActive : undefined,
   averageConfidence: props.averageConfidence !== undefined ? props.averageConfidence : undefined,
@@ -1094,6 +1100,9 @@ import { logger } from './utils/logger';
   windowMaxDrawdownPct: prop.windowMaxDrawdownPct !== undefined ? prop.windowMaxDrawdownPct : undefined,
   windowCumulativePnlAmt: prop.windowCumulativePnlAmt !== undefined ? prop.windowCumulativePnlAmt : undefined,
   backtestExpectancy: prop.backtestExpectancy !== undefined ? prop.backtestExpectancy : undefined,
+  backtestHitRate: prop.backtestHitRate !== undefined ? prop.backtestHitRate : undefined,
+  backtestHitRateStdDev: prop.backtestHitRateStdDev !== undefined ? prop.backtestHitRateStdDev : undefined,
+  backtestExpectancyStdDev: prop.backtestExpectancyStdDev !== undefined ? prop.backtestExpectancyStdDev : undefined,
   divergenceZScore: prop.divergenceZScore !== undefined ? prop.divergenceZScore : undefined,
   divergenceAlertActive: prop.divergenceAlertActive !== undefined ? prop.divergenceAlertActive : undefined,
   averageConfidence: prop.averageConfidence !== undefined ? prop.averageConfidence : undefined,
@@ -1291,6 +1300,15 @@ import { logger } from './utils/logger';
            } : undefined,
   backtestExpectancy: props.backtestExpectancy !== undefined ? {
             set: props.backtestExpectancy 
+           } : undefined,
+  backtestHitRate: props.backtestHitRate !== undefined ? {
+            set: props.backtestHitRate 
+           } : undefined,
+  backtestHitRateStdDev: props.backtestHitRateStdDev !== undefined ? {
+            set: props.backtestHitRateStdDev 
+           } : undefined,
+  backtestExpectancyStdDev: props.backtestExpectancyStdDev !== undefined ? {
+            set: props.backtestExpectancyStdDev 
            } : undefined,
   divergenceZScore: props.divergenceZScore !== undefined ? {
             set: props.divergenceZScore 
@@ -4044,6 +4062,9 @@ import { logger } from './utils/logger';
   windowMaxDrawdownPct: props.windowMaxDrawdownPct !== undefined ? props.windowMaxDrawdownPct : undefined,
   windowCumulativePnlAmt: props.windowCumulativePnlAmt !== undefined ? props.windowCumulativePnlAmt : undefined,
   backtestExpectancy: props.backtestExpectancy !== undefined ? props.backtestExpectancy : undefined,
+  backtestHitRate: props.backtestHitRate !== undefined ? props.backtestHitRate : undefined,
+  backtestHitRateStdDev: props.backtestHitRateStdDev !== undefined ? props.backtestHitRateStdDev : undefined,
+  backtestExpectancyStdDev: props.backtestExpectancyStdDev !== undefined ? props.backtestExpectancyStdDev : undefined,
   divergenceZScore: props.divergenceZScore !== undefined ? props.divergenceZScore : undefined,
   divergenceAlertActive: props.divergenceAlertActive !== undefined ? props.divergenceAlertActive : undefined,
   averageConfidence: props.averageConfidence !== undefined ? props.averageConfidence : undefined,
@@ -4754,6 +4775,15 @@ import { logger } from './utils/logger';
            } : undefined,
   backtestExpectancy: props.backtestExpectancy !== undefined ? {
             set: props.backtestExpectancy 
+           } : undefined,
+  backtestHitRate: props.backtestHitRate !== undefined ? {
+            set: props.backtestHitRate 
+           } : undefined,
+  backtestHitRateStdDev: props.backtestHitRateStdDev !== undefined ? {
+            set: props.backtestHitRateStdDev 
+           } : undefined,
+  backtestExpectancyStdDev: props.backtestExpectancyStdDev !== undefined ? {
+            set: props.backtestExpectancyStdDev 
            } : undefined,
   divergenceZScore: props.divergenceZScore !== undefined ? {
             set: props.divergenceZScore 
@@ -7530,6 +7560,15 @@ import { logger } from './utils/logger';
            } : undefined,
   backtestExpectancy: prop.backtestExpectancy !== undefined ? {
             set: prop.backtestExpectancy 
+           } : undefined,
+  backtestHitRate: prop.backtestHitRate !== undefined ? {
+            set: prop.backtestHitRate 
+           } : undefined,
+  backtestHitRateStdDev: prop.backtestHitRateStdDev !== undefined ? {
+            set: prop.backtestHitRateStdDev 
+           } : undefined,
+  backtestExpectancyStdDev: prop.backtestExpectancyStdDev !== undefined ? {
+            set: prop.backtestExpectancyStdDev 
            } : undefined,
   divergenceZScore: prop.divergenceZScore !== undefined ? {
             set: prop.divergenceZScore 

--- a/src/TradingPolicy.ts
+++ b/src/TradingPolicy.ts
@@ -650,6 +650,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2847,6 +2850,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -2877,6 +2889,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3641,6 +3656,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5550,6 +5568,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7354,6 +7375,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -7384,6 +7414,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8148,6 +8181,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -10935,6 +10971,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -10965,6 +11010,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -11729,6 +11777,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/User.ts
+++ b/src/User.ts
@@ -695,6 +695,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2375,6 +2378,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -2405,6 +2417,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3055,6 +3070,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4113,6 +4131,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5469,6 +5490,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -5499,6 +5529,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6149,6 +6182,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7862,6 +7898,15 @@ import { logger } from './utils/logger';
           backtestExpectancy: item.backtestExpectancy !== undefined ? {
               set: item.backtestExpectancy
             } : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? {
+              set: item.backtestHitRate
+            } : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+              set: item.backtestHitRateStdDev
+            } : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+              set: item.backtestExpectancyStdDev
+            } : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? {
               set: item.divergenceZScore
             } : undefined,
@@ -7892,6 +7937,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8542,6 +8590,9 @@ import { logger } from './utils/logger';
           windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
           windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
           backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+          backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+          backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+          backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
           divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
           divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
           averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,

--- a/src/WaitlistEntry.ts
+++ b/src/WaitlistEntry.ts
@@ -495,6 +495,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -1999,6 +2002,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -2029,6 +2041,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -2387,6 +2402,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3037,6 +3055,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -3805,6 +3826,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -4988,6 +5012,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -5018,6 +5051,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -5376,6 +5412,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -6026,6 +6065,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7396,6 +7438,15 @@ import { logger } from './utils/logger';
             backtestExpectancy: item.backtestExpectancy !== undefined ? {
                 set: item.backtestExpectancy
               } : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? {
+                set: item.backtestHitRate
+              } : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? {
+                set: item.backtestHitRateStdDev
+              } : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? {
+                set: item.backtestExpectancyStdDev
+              } : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? {
                 set: item.divergenceZScore
               } : undefined,
@@ -7426,6 +7477,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -7784,6 +7838,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,
@@ -8434,6 +8491,9 @@ import { logger } from './utils/logger';
             windowMaxDrawdownPct: item.windowMaxDrawdownPct !== undefined ? item.windowMaxDrawdownPct : undefined,
             windowCumulativePnlAmt: item.windowCumulativePnlAmt !== undefined ? item.windowCumulativePnlAmt : undefined,
             backtestExpectancy: item.backtestExpectancy !== undefined ? item.backtestExpectancy : undefined,
+            backtestHitRate: item.backtestHitRate !== undefined ? item.backtestHitRate : undefined,
+            backtestHitRateStdDev: item.backtestHitRateStdDev !== undefined ? item.backtestHitRateStdDev : undefined,
+            backtestExpectancyStdDev: item.backtestExpectancyStdDev !== undefined ? item.backtestExpectancyStdDev : undefined,
             divergenceZScore: item.divergenceZScore !== undefined ? item.divergenceZScore : undefined,
             divergenceAlertActive: item.divergenceAlertActive !== undefined ? item.divergenceAlertActive : undefined,
             averageConfidence: item.averageConfidence !== undefined ? item.averageConfidence : undefined,


### PR DESCRIPTION
## Summary

Adds three new nullable fields to `StrategyHealthSnapshot` enabling the engine's `SignalDegradationObserver` to compute real z-score degradation against backtest baselines:

- `backtestHitRate Float?` — historical baseline hit-rate from backtest
- `backtestHitRateStdDev Float?` — standard deviation of hit-rate (z-score denominator)
- `backtestExpectancyStdDev Float?` — standard deviation of expectancy (z-score denominator)

All fields are nullable so legacy rows are unaffected. The `SignalDegradationObserver` already handles nulls gracefully (no-op when baseline is missing).

## Changes

- `prisma/schema.prisma` — 3 new `Float?` fields on `StrategyHealthSnapshot`
- `prisma/migrations/20260518100000_strategyhealthsnapshot_backtest_fields/migration.sql` — idempotent `DO $$ ... IF NOT EXISTS` guards for all 3 columns
- `src/StrategyHealthSnapshot.ts` — selection set + all mutation variable mappings updated (create, createMany, update, upsert, updateMany)
- 17 relationship files (`src/AlpacaAccount.ts`, `src/Account.ts`, etc.) — auto-propagated by `generate:functions` with new field CRUD mappings
- `src/generated/typegraphql-prisma/` — Prisma Client + TypeGraphQL regenerated (v6.19.3)

## Test plan

- [ ] Migration applies cleanly via `prisma migrate deploy`
- [ ] Migration is idempotent (re-running is safe)
- [ ] Existing rows have NULL for the new fields (no data loss)
- [ ] `@adaptic/backend-legacy` build passes with regenerated types
- [ ] Engine `SignalDegradationObserver` can read `backtestHitRate` / `backtestHitRateStdDev` / `backtestExpectancyStdDev` from live snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)