### PR TITLE
security: CORTEX-P0-001 shadow-first authChecker + rate-limiter observability

### DIFF
--- a/src/auth/__tests__/cortex-auth-checker.test.ts
+++ b/src/auth/__tests__/cortex-auth-checker.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { ResolverData } from 'type-graphql';
+import type { GraphQLResolveInfo } from 'graphql';
+import {
+  cortexAuthChecker,
+  cortexAuthCheckerWouldDenyTotal,
+  evaluateWouldAllow,
+  isAuthCheckerEnforced,
+  CORTEX_AUTHCHECKER_ENFORCE_ENV,
+  type CortexAuthContext,
+} from '../cortex-auth-checker';
+import type { BackendPrincipal } from '../token-verifier';
+
+/**
+ * CORTEX-P0-001 unit tests for the resolver-level authorization AuthChecker.
+ *
+ * The SHADOW-FIRST contract is safety-critical: with enforcement OFF (default)
+ * the checker MUST allow every operation while still counting would-denies; with
+ * enforcement ON it MUST fail closed for a would-deny; a server principal MUST
+ * always be allowed regardless of mode. These properties gate the shadow→enforce
+ * rollout, so they are proven in isolation here.
+ */
+
+const USER_SUB = '99999999-9999-9999-9999-999999999999';
+
+function buildResolverData(
+  principal: BackendPrincipal | null,
+  operationName = 'TestOp',
+  fieldName = 'funds'
+): ResolverData<CortexAuthContext> {
+  const info = {
+    fieldName,
+    operation: {
+      operation: 'query',
+      name: { value: operationName },
+    },
+  } as unknown as GraphQLResolveInfo;
+
+  return {
+    root: undefined,
+    args: {},
+    context: { principal },
+    info,
+  };
+}
+
+/** Read the current value of the would-deny counter for a given reason. */
+async function wouldDenyCount(reason: string): Promise<number> {
+  const metric = await cortexAuthCheckerWouldDenyTotal.get();
+  const sample = metric.values.find((v) => v.labels.reason === reason);
+  return sample?.value ?? 0;
+}
+
+const SERVER_PRINCIPAL: BackendPrincipal = { kind: 'server' };
+const USER_PRINCIPAL: BackendPrincipal = {
+  kind: 'user',
+  sub: USER_SUB,
+  roles: ['user'],
+};
+const ADMIN_PRINCIPAL: BackendPrincipal = {
+  kind: 'admin',
+  sub: USER_SUB,
+  roles: ['admin'],
+};
+
+describe('isAuthCheckerEnforced', () => {
+  it('defaults to false (shadow) when unset or unrecognised', () => {
+    expect(isAuthCheckerEnforced({})).toBe(false);
+    expect(
+      isAuthCheckerEnforced({ [CORTEX_AUTHCHECKER_ENFORCE_ENV]: 'bogus' })
+    ).toBe(false);
+    expect(
+      isAuthCheckerEnforced({ [CORTEX_AUTHCHECKER_ENFORCE_ENV]: 'false' })
+    ).toBe(false);
+  });
+
+  it('is true only for explicit true / 1', () => {
+    expect(
+      isAuthCheckerEnforced({ [CORTEX_AUTHCHECKER_ENFORCE_ENV]: 'true' })
+    ).toBe(true);
+    expect(
+      isAuthCheckerEnforced({ [CORTEX_AUTHCHECKER_ENFORCE_ENV]: ' TRUE ' })
+    ).toBe(true);
+    expect(
+      isAuthCheckerEnforced({ [CORTEX_AUTHCHECKER_ENFORCE_ENV]: '1' })
+    ).toBe(true);
+  });
+});
+
+describe('evaluateWouldAllow', () => {
+  it('denies a null principal as unauthenticated', () => {
+    expect(evaluateWouldAllow(null, [])).toEqual({
+      wouldAllow: false,
+      reason: 'unauthenticated',
+    });
+  });
+
+  it('always allows a server principal, even with required roles', () => {
+    expect(evaluateWouldAllow(SERVER_PRINCIPAL, [])).toEqual({
+      wouldAllow: true,
+    });
+    expect(evaluateWouldAllow(SERVER_PRINCIPAL, ['admin'])).toEqual({
+      wouldAllow: true,
+    });
+  });
+
+  it('allows an authenticated user when no role is required', () => {
+    expect(evaluateWouldAllow(USER_PRINCIPAL, [])).toEqual({ wouldAllow: true });
+  });
+
+  it('denies a user lacking a required role', () => {
+    expect(evaluateWouldAllow(USER_PRINCIPAL, ['admin'])).toEqual({
+      wouldAllow: false,
+      reason: 'insufficient_role',
+    });
+  });
+
+  it('allows an admin principal for an admin-gated field', () => {
+    expect(evaluateWouldAllow(ADMIN_PRINCIPAL, ['admin'])).toEqual({
+      wouldAllow: true,
+    });
+  });
+});
+
+describe('cortexAuthChecker', () => {
+  beforeEach(() => {
+    delete process.env[CORTEX_AUTHCHECKER_ENFORCE_ENV];
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env[CORTEX_AUTHCHECKER_ENFORCE_ENV];
+  });
+
+  it('shadow mode: allows a null-principal op while incrementing the would-deny counter', async () => {
+    const before = await wouldDenyCount('unauthenticated');
+    const allowed = cortexAuthChecker(buildResolverData(null), []);
+
+    expect(allowed).toBe(true);
+    expect(await wouldDenyCount('unauthenticated')).toBe(before + 1);
+  });
+
+  it('enforce mode: denies a null-principal op (fail closed)', () => {
+    process.env[CORTEX_AUTHCHECKER_ENFORCE_ENV] = 'true';
+    const allowed = cortexAuthChecker(buildResolverData(null), []);
+    expect(allowed).toBe(false);
+  });
+
+  it('always allows a server principal in shadow mode', () => {
+    const allowed = cortexAuthChecker(
+      buildResolverData(SERVER_PRINCIPAL),
+      ['admin']
+    );
+    expect(allowed).toBe(true);
+  });
+
+  it('always allows a server principal in enforce mode', () => {
+    process.env[CORTEX_AUTHCHECKER_ENFORCE_ENV] = 'true';
+    const allowed = cortexAuthChecker(
+      buildResolverData(SERVER_PRINCIPAL),
+      ['admin']
+    );
+    expect(allowed).toBe(true);
+  });
+
+  it('enforce mode: denies a user lacking a required role', () => {
+    process.env[CORTEX_AUTHCHECKER_ENFORCE_ENV] = 'true';
+    const allowed = cortexAuthChecker(
+      buildResolverData(USER_PRINCIPAL),
+      ['admin']
+    );
+    expect(allowed).toBe(false);
+  });
+});

--- a/src/auth/cortex-auth-checker.ts
+++ b/src/auth/cortex-auth-checker.ts
@@ -1,0 +1,208 @@
+/**
+ * CORTEX-P0-001 — resolver-level authorization AuthChecker (SHADOW-FIRST).
+ *
+ * A TypeGraphQL {@link AuthChecker} that evaluates whether an operation WOULD be
+ * allowed under resolver-level authorization, closing the residual vector called
+ * out in the tenancy-scoping middleware docs: a governed model reached
+ * transitively through a non-governed root, and — more broadly — any
+ * `@Authorized()`-decorated field executed without a verified principal.
+ *
+ * CRITICAL SAFETY CONTRACT — this change is additive and default-OFF. When
+ * enforcement is OFF (the default), the checker NEVER denies: it returns `true`
+ * for every operation, emitting a structured warn log and incrementing a
+ * Prometheus counter for any operation that enforcement WOULD deny. Live
+ * behaviour is byte-identical to before this change until
+ * `CORTEX_AUTHCHECKER_ENFORCE` is flipped on. Additionally, TypeGraphQL only
+ * invokes an AuthChecker for fields decorated with `@Authorized()`; the
+ * auto-generated typegraphql-prisma resolvers carry no such decorator, so
+ * registering this checker via `buildSchema({ authChecker })` is inert at
+ * runtime until decorators are added in the separate enforcement phase.
+ *
+ * Decision model (mirrors the token-verifier principal kinds):
+ *
+ *   - `server`            — trusted server-to-server caller. ALWAYS allowed; the
+ *     engine + utils call the CRUD resolvers with a server principal and must
+ *     retain full access, bypassing any role gate.
+ *   - `admin` / `user`    — verified end-user. Allowed when the field requires no
+ *     specific role, or when the principal carries one of the required roles;
+ *     otherwise a would-deny with reason `insufficient_role`.
+ *   - `null` (no verified principal) — a genuinely unauthenticated caller on a
+ *     non-public (i.e. `@Authorized()`) operation. A would-deny with reason
+ *     `unauthenticated`.
+ *
+ * @see src/auth/tenancy-scope.ts for the row-level (data-scope) counterpart.
+ * @see src/auth/token-verifier.ts for `BackendPrincipal`.
+ */
+
+import { Counter } from 'prom-client';
+import type { AuthChecker, ResolverData } from 'type-graphql';
+import type { BackendPrincipal } from './token-verifier';
+import { metricsRegistry } from '../config/metrics';
+import { logger } from '../utils/logger';
+
+// -----------------------------------------------------------------------------
+// Enforcement flag
+// -----------------------------------------------------------------------------
+
+/**
+ * Environment variable gating enforcement. When set to `true`/`1`, the checker
+ * fails closed (returns `false`) for any would-deny operation. Unset or any
+ * other value keeps the checker in SHADOW mode (observe + count + allow).
+ */
+export const CORTEX_AUTHCHECKER_ENFORCE_ENV = 'CORTEX_AUTHCHECKER_ENFORCE';
+
+/** The `admin` role string used to satisfy admin-gated `@Authorized()` fields. */
+const ADMIN_ROLE = 'admin';
+
+/**
+ * Whether resolver-level authorization enforcement is ON. Read fresh on each
+ * call (a cheap env read) so the shadow→enforce graduation can be flipped
+ * operationally without a process restart — the same pattern the tenancy-scoping
+ * middleware uses. Defaults to OFF (shadow) for any unset/unrecognised value.
+ *
+ * @param env - Environment source (defaults to `process.env`); injectable for tests.
+ * @returns `true` only when the flag is explicitly `true`/`1`.
+ */
+export function isAuthCheckerEnforced(
+  env: Record<string, string | undefined> = process.env
+): boolean {
+  const raw = (env[CORTEX_AUTHCHECKER_ENFORCE_ENV] ?? '').trim().toLowerCase();
+  return raw === 'true' || raw === '1';
+}
+
+// -----------------------------------------------------------------------------
+// Would-deny classification + metric
+// -----------------------------------------------------------------------------
+
+/**
+ * Finite set of reasons enforcement WOULD deny an operation. Used as the sole
+ * label on {@link cortexAuthCheckerWouldDenyTotal}.
+ */
+export type WouldDenyReason = 'unauthenticated' | 'insufficient_role';
+
+/**
+ * Counts operations that resolver-level authorization WOULD deny. In shadow mode
+ * this is the primary signal proving whether flipping `CORTEX_AUTHCHECKER_ENFORCE`
+ * to `enforce` would reject any legitimate platform or engine traffic. Labelled
+ * by the discriminated {@link WouldDenyReason}.
+ */
+export const cortexAuthCheckerWouldDenyTotal = new Counter({
+  name: 'cortex_authchecker_would_deny_total',
+  help: 'Operations resolver-level authorization would deny, by reason (counted in shadow mode without denying)',
+  labelNames: ['reason'] as const,
+  registers: [metricsRegistry],
+});
+
+/** The outcome of evaluating whether an operation would be allowed. */
+interface AuthEvaluation {
+  readonly wouldAllow: boolean;
+  /** Populated only when `wouldAllow` is `false`. */
+  readonly reason?: WouldDenyReason;
+}
+
+/**
+ * Pure evaluation of whether a principal would satisfy the required roles for an
+ * operation. Performs no I/O and no logging.
+ *
+ * @param principal - The verified principal, or `null` for an unauthenticated caller.
+ * @param requiredRoles - Roles declared on the field's `@Authorized(...)` decorator
+ *   (empty when the field only requires authentication).
+ * @returns The {@link AuthEvaluation}.
+ */
+export function evaluateWouldAllow(
+  principal: BackendPrincipal | null,
+  requiredRoles: readonly string[]
+): AuthEvaluation {
+  if (!principal) {
+    return { wouldAllow: false, reason: 'unauthenticated' };
+  }
+
+  // Server-to-server callers are unconditionally allowed and bypass role gates.
+  if (principal.kind === 'server') {
+    return { wouldAllow: true };
+  }
+
+  // Authenticated user/admin with no specific role requirement -> allowed.
+  if (requiredRoles.length === 0) {
+    return { wouldAllow: true };
+  }
+
+  const principalRoles =
+    principal.kind === 'admin'
+      ? [...principal.roles, ADMIN_ROLE]
+      : principal.roles;
+  const roleSet = new Set(principalRoles);
+  const hasRequiredRole = requiredRoles.some((role) => roleSet.has(role));
+
+  return hasRequiredRole
+    ? { wouldAllow: true }
+    : { wouldAllow: false, reason: 'insufficient_role' };
+}
+
+// -----------------------------------------------------------------------------
+// AuthChecker
+// -----------------------------------------------------------------------------
+
+/**
+ * GraphQL context shape this checker reads. `principal` is the verified
+ * `BackendPrincipal` attached to the context in `server.ts` (`null` for an
+ * unauthenticated caller).
+ */
+export interface CortexAuthContext {
+  principal?: BackendPrincipal | null;
+}
+
+/** Describe an operation for structured logs, without leaking arguments. */
+function describeOperation(
+  resolverData: ResolverData<CortexAuthContext>
+): { operationType: string; operationName: string; field: string } {
+  const { info } = resolverData;
+  return {
+    operationType: info.operation.operation,
+    operationName: info.operation.name?.value ?? info.fieldName,
+    field: info.fieldName,
+  };
+}
+
+/**
+ * The CORTEX-P0-001 AuthChecker. Register via
+ * `buildSchema({ authChecker: cortexAuthChecker })`.
+ *
+ * SHADOW (default): a would-deny operation increments
+ * {@link cortexAuthCheckerWouldDenyTotal}, emits a warn log, and RETURNS TRUE —
+ * no behaviour change. ENFORCE (`CORTEX_AUTHCHECKER_ENFORCE=true`): a would-deny
+ * operation is logged, the counter is incremented, and the checker RETURNS FALSE
+ * (fail closed). Operations that would be allowed always return `true` with no
+ * metric or log emission.
+ */
+export const cortexAuthChecker: AuthChecker<CortexAuthContext> = (
+  resolverData,
+  roles
+): boolean => {
+  const principal = resolverData.context.principal ?? null;
+  const evaluation = evaluateWouldAllow(principal, roles);
+
+  if (evaluation.wouldAllow) {
+    return true;
+  }
+
+  const reason = evaluation.reason ?? 'unauthenticated';
+  const enforced = isAuthCheckerEnforced();
+  const operation = describeOperation(resolverData);
+
+  cortexAuthCheckerWouldDenyTotal.inc({ reason });
+  logger.warn(
+    enforced
+      ? '[cortex-authchecker] denying operation (enforce)'
+      : '[cortex-authchecker] shadow would-deny (allowing)',
+    {
+      ...operation,
+      reason,
+      enforced,
+      principalKind: principal?.kind ?? 'none',
+      requiredRoles: [...roles],
+    }
+  );
+
+  return !enforced;
+};

--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -1,8 +1,53 @@
-// Integration: add to server.ts - app.use('/graphql', graphqlRateLimiter) and app.use('/auth', authRateLimiter)
+// CORTEX-P0-001: mounted in server.ts as
+//   app.use('/graphql', graphqlRateLimiter)   // GraphQL surface
+//   app.use('/api', authRateLimiter)          // authenticated Express surface
+// SHADOW-FIRST: 429 enforcement is gated behind CORTEX_RATE_LIMIT_ENFORCE.
+// While OFF (default), the limiters observe + count requests that WOULD be
+// blocked but never touch the response — live behaviour is byte-identical.
 
 import { Request, Response, NextFunction } from 'express';
+import { Counter } from 'prom-client';
+import { metricsRegistry } from '../config/metrics';
+import { logger } from '../utils/logger';
+
+/**
+ * Environment variable gating 429 enforcement. When set to `true`/`1`, the
+ * limiters block over-limit requests with HTTP 429. Unset or any other value
+ * keeps them in SHADOW mode (observe + count + always proceed).
+ */
+export const CORTEX_RATE_LIMIT_ENFORCE_ENV = 'CORTEX_RATE_LIMIT_ENFORCE';
+
+/**
+ * Whether rate-limit 429 enforcement is ON. Read fresh on each request (a cheap
+ * env read) so the shadow→enforce graduation can be flipped operationally
+ * without a restart. Defaults to OFF (shadow) for any unset/unrecognised value.
+ *
+ * @param env - Environment source (defaults to `process.env`); injectable for tests.
+ * @returns `true` only when the flag is explicitly `true`/`1`.
+ */
+export function isRateLimitEnforced(
+  env: Record<string, string | undefined> = process.env
+): boolean {
+  const raw = (env[CORTEX_RATE_LIMIT_ENFORCE_ENV] ?? '').trim().toLowerCase();
+  return raw === 'true' || raw === '1';
+}
+
+/**
+ * Counts requests that rate limiting WOULD block (HTTP 429). In shadow mode this
+ * is the signal proving whether flipping `CORTEX_RATE_LIMIT_ENFORCE` to enforce
+ * would reject legitimate traffic. Labelled by the `limiter` name
+ * (`graphql`/`auth`) and the request `tier` (`auth`/`anon`).
+ */
+export const cortexRateLimitWouldBlockTotal = new Counter({
+  name: 'cortex_rate_limit_would_block_total',
+  help: 'Requests rate limiting would block (429), by limiter and tier (counted in shadow mode without blocking)',
+  labelNames: ['limiter', 'tier'] as const,
+  registers: [metricsRegistry],
+});
 
 interface RateLimitConfig {
+  /** Stable limiter identifier used as the `limiter` metric label. */
+  name: string;
   windowMs: number;
   maxAuthenticated: number;
   maxUnauthenticated: number;
@@ -68,10 +113,11 @@ function createRateLimiter(config: RateLimitConfig) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const identifier = req.ip || req.connection.remoteAddress || 'unknown';
     const authenticated = isAuthenticated(req);
+    const tier = authenticated ? 'auth' : 'anon';
     const effectiveMax = authenticated
       ? config.maxAuthenticated
       : config.maxUnauthenticated;
-    const storeKey = `${identifier}:${authenticated ? 'auth' : 'anon'}`;
+    const storeKey = `${identifier}:${tier}`;
     const now = Date.now();
 
     if (!store[storeKey] || store[storeKey].resetTime < now) {
@@ -86,17 +132,39 @@ function createRateLimiter(config: RateLimitConfig) {
     const current = store[storeKey];
     const remaining = Math.max(0, effectiveMax - current.count);
     const resetSeconds = Math.ceil((current.resetTime - now) / 1000);
+    const overLimit = current.count > effectiveMax;
 
-    // Add rate limit headers
+    // SHADOW mode (default): observe + count over-limit requests but NEVER touch
+    // the response — no rate-limit headers, no 429. This keeps live behaviour
+    // byte-identical until CORTEX_RATE_LIMIT_ENFORCE is flipped on.
+    if (!isRateLimitEnforced()) {
+      if (overLimit) {
+        cortexRateLimitWouldBlockTotal.inc({ limiter: config.name, tier });
+        logger.warn('[cortex-rate-limit] shadow would-block (allowing)', {
+          limiter: config.name,
+          identifier,
+          tier,
+          count: current.count,
+          limit: effectiveMax,
+          resetSeconds,
+        });
+      }
+      next();
+      return;
+    }
+
+    // ENFORCE mode: emit the informational rate-limit headers and block
+    // over-limit requests with HTTP 429.
     if (config.standardHeaders !== false) {
       res.setHeader('X-RateLimit-Limit', effectiveMax.toString());
       res.setHeader('X-RateLimit-Remaining', remaining.toString());
       res.setHeader('X-RateLimit-Reset', resetSeconds.toString());
     }
 
-    if (current.count > effectiveMax) {
+    if (overLimit) {
       // Include Retry-After header on 429 responses (RFC 6585 / RFC 7231)
       res.setHeader('Retry-After', resetSeconds.toString());
+      cortexRateLimitWouldBlockTotal.inc({ limiter: config.name, tier });
       res.status(429).json(config.message);
       return;
     }
@@ -112,6 +180,7 @@ function createRateLimiter(config: RateLimitConfig) {
  * Unauthenticated requests: 200 requests per 15 minutes (configurable via RATE_LIMIT_MAX_UNAUTH)
  */
 export const graphqlRateLimiter = createRateLimiter({
+  name: 'graphql',
   windowMs: 15 * 60 * 1000, // 15 minutes
   maxAuthenticated: parseInt(process.env.RATE_LIMIT_MAX || '1000', 10),
   maxUnauthenticated: parseInt(process.env.RATE_LIMIT_MAX_UNAUTH || '200', 10),
@@ -129,6 +198,7 @@ export const graphqlRateLimiter = createRateLimiter({
  * Unauthenticated requests: 20 requests per 15 minutes
  */
 export const authRateLimiter = createRateLimiter({
+  name: 'auth',
   windowMs: 15 * 60 * 1000, // 15 minutes
   maxAuthenticated: 50,
   maxUnauthenticated: 20,

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,8 +23,13 @@ import bodyParser from 'body-parser';
 import { WebSocketServer } from 'ws';
 import { useServer } from 'graphql-ws/lib/use/ws';
 import { authMiddleware } from './middleware/auth';
+import {
+  graphqlRateLimiter,
+  authRateLimiter,
+} from './middleware/rate-limiter';
 import { createAuditLogPlugin } from './middleware/audit-logger';
 import { createTenancyScopingMiddleware } from './middleware/tenancy-scoping';
+import { cortexAuthChecker } from './auth/cortex-auth-checker';
 import { createHttpStatusMapperPlugin } from './plugins/http-status-mapper';
 import { createValidationPlugin } from './middleware/graphql-validation-plugin';
 import { createQueryComplexityPlugin } from './middleware/query-complexity';
@@ -118,6 +123,11 @@ const startServer = async () => {
     // and unauthenticated callers are bypassed in every mode. Gated by
     // `TENANCY_SCOPING_MODE` (default `shadow`).
     globalMiddlewares: [createTenancyScopingMiddleware()],
+    // Resolver-level authorization (CORTEX-P0-001). SHADOW-FIRST: only invoked
+    // for `@Authorized()`-decorated fields and, while `CORTEX_AUTHCHECKER_ENFORCE`
+    // is OFF (default), it observes + counts would-deny operations but always
+    // allows — byte-identical live behaviour until enforcement is flipped on.
+    authChecker: cortexAuthChecker,
   });
 
   const app = express();
@@ -126,6 +136,14 @@ const startServer = async () => {
   // HTTP request metrics — must be mounted early to capture every request.
   // The middleware is a no-op when metrics are disabled.
   app.use(metricsMiddleware);
+
+  // Rate limiting (CORTEX-P0-001). SHADOW-FIRST: mounted on the GraphQL surface
+  // and the authenticated Express `/api` surface. While `CORTEX_RATE_LIMIT_ENFORCE`
+  // is OFF (default), they observe + count requests that WOULD be blocked but
+  // never touch the response, so live behaviour is byte-identical. Mounted
+  // before `/api` auth so limiting precedes the (more expensive) auth work.
+  app.use('/graphql', graphqlRateLimiter);
+  app.use('/api', authRateLimiter);
 
   app.use('/api', (req, res, next) =>
     authMiddleware(req as AuthenticatedRequest, res, next)


### PR DESCRIPTION
**Shadow-first phase 1 of CORTEX-P0-001.** Additive, default-OFF — **byte-identical live behavior until an env flag is flipped**. Makes the unauthenticated-CRUD / no-rate-limit gap fully visible in metrics + logs without breaking any client.

### What it adds
- **`src/auth/cortex-auth-checker.ts`** — a TypeGraphQL `AuthChecker` in SHADOW mode. On a would-deny (null principal / insufficient role on a non-public op) it increments `cortex_authchecker_would_deny_total{reason}` + a structured warn log, then **allows through**. `CORTEX_AUTHCHECKER_ENFORCE=true` flips it to fail-closed. Server-kind principal always allowed. Registered via `buildSchema({ authChecker })`.
- **`rate-limiter.ts` + `server.ts`** — mounts the previously-unmounted `graphqlRateLimiter` (`/graphql`) + `authRateLimiter` (`/api`), gated by `CORTEX_RATE_LIMIT_ENFORCE` (default OFF → count over-limit via `cortex_rate_limit_would_block_total` + log, always `next()`; ON → informational headers + 429).
- **12 co-located tests** (shadow allows+counts, enforce denies, server always allowed) — all pass.

### Deliberately NOT in this PR (gated phase 2, needs your validation)
Flipping the enforce flags, credential-field `GQL.SKIP` excision, and tenancy-enforce. Your existing **PR #7** (the comprehensive May enforcement work) is the phase-2 reference — but it's 118 commits stale; this shadow-first phase 1 is the low-risk, mergeable starting point.

### Honest caveat
TypeGraphQL only invokes the `authChecker` on `@Authorized()`-decorated fields; the *generated* CRUD resolvers carry none today, so the checker is **registered-but-inert at runtime** until phase 2 annotates authorization. The **rate-limiter observability is live-in-shadow now**. Verified via `tsc` on the touched files (the repo's codegen was intentionally not run to avoid churning generated model files, so full `npm run build` validation happens in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
