### PR TITLE
security: CORTEX-P0-001 phase-2 READINESS (server-only credential resolver + enablement runbook) — REVIEW ONLY

### DIFF
--- a/docs/security/cortex-p0-001-enablement.md
+++ b/docs/security/cortex-p0-001-enablement.md
@@ -1,0 +1,144 @@
+# CORTEX-P0-001 — Enablement Runbook
+
+**Status:** Readiness mechanism landed; enforcement NOT enabled.
+**Audience:** on-call / release engineer flipping the CORTEX guards from shadow to
+enforce.
+**Golden rule:** every step below is validated against real shadow evidence
+BEFORE the next one. Nothing in this sequence is time-boxed to "before market
+open" — the enforce flips in particular must never be done immediately before a
+US equities open.
+
+CORTEX-P0-001 hardens the `@adaptic/backend-legacy` GraphQL surface in three
+independent planes, each shadow-first and default-off:
+
+| Plane | Flag | Shadow signal |
+| --- | --- | --- |
+| Resolver authorization | `CORTEX_AUTHCHECKER_ENFORCE` | `cortex_authchecker_would_deny_total` |
+| Rate limiting | `CORTEX_RATE_LIMIT_ENFORCE` | `cortex_rate_limit_would_block_total` |
+| Row-level tenancy | `TENANCY_SCOPING_MODE` (`shadow`→`enforce`) | tenancy would-scope counters |
+
+A fourth, orthogonal workstream — **credential excision** — removes the plaintext
+`AlpacaAccount.APIKey` / `APISecret` fields from the GraphQL schema. It has a hard
+ordering dependency on the server-only credential resolver and the engine
+migration, spelled out below.
+
+---
+
+## Why ordering matters
+
+The engine authenticates to Alpaca with credentials it reads **today** as
+ordinary GraphQL fields (`AlpacaAccount.APIKey`, `AlpacaAccount.APISecret`). Those
+fields are selectable by any authenticated caller — that is the exposure
+CORTEX-P0-001 closes. But they cannot simply be hidden: the moment `GQL.SKIP` is
+applied and the package regenerated, the engine's credential read returns
+`undefined` and **every account stops trading**.
+
+Therefore the safe path is: build a replacement fetch path FIRST, move the engine
+onto it, and only THEN remove the old fields. The same logic applies to any
+enforce flag: prove in shadow that no legitimate traffic would be denied BEFORE
+failing closed.
+
+---
+
+## Ordered enablement sequence
+
+### (a) Run phase-1 shadow in production and watch the counters
+
+Phase-1 (PR #11) is already merged and default-off: the authChecker and rate
+limiter observe-and-count but never deny/block; tenancy stays in `shadow`.
+
+1. Deploy `stable-release` with all flags unset (shadow).
+2. Watch, over a representative window (at least one full trading day plus an
+   off-hours window; longer is better):
+   - `cortex_authchecker_would_deny_total` — must show **no** would-denies for
+     legitimate engine (`server`-principal) or platform (`user`/`admin`) traffic.
+     Any nonzero `server` would-deny is a bug to fix before proceeding.
+   - `cortex_rate_limit_would_block_total` — confirm the thresholds do not clip
+     legitimate burst traffic (engine reconnect storms, screener fan-out).
+   - tenancy would-scope counters — confirm only genuinely cross-tenant reads are
+     flagged.
+3. Do not advance until the shadow evidence is clean and understood. This is the
+   gate for the entire rollout.
+
+### (b) Annotate resolvers / require principals
+
+Add `@Authorized(...)` decorators (and any required-role declarations) to the
+resolvers that should be gated. Until this step the authChecker is inert even in
+enforce mode, because TypeGraphQL only invokes the checker for `@Authorized()`
+fields. Land these annotations while still in shadow and re-observe (a) — the
+counters now reflect the real decorated surface.
+
+### (c) Migrate the engine to the server-only credential resolver
+
+This repo now ships the migration target: the **`alpacaAccountCredentials`**
+query (`src/resolvers/custom/AlpacaAccountCredentialsResolver.ts`).
+
+- It returns `APIKey` / `APISecret` (and the `type` discriminator) for an account
+  **only** to the engine's `server` principal (established by an exact
+  `SERVER_AUTH_TOKEN` match in `verifyBackendToken`). Every non-server or
+  unauthenticated caller is rejected with a `FORBIDDEN` error before Prisma is
+  touched. The gate is enforced in-resolver and fails closed — it does **not**
+  depend on `CORTEX_AUTHCHECKER_ENFORCE`.
+- Observability: `cortex_alpaca_credential_access_total{outcome}` counts
+  `granted` / `denied_non_server` / `not_found`. After the engine migrates,
+  `granted` should track the engine's credential reads and `denied_non_server`
+  should stay at zero.
+
+Engine-side change (separate PR, in `~/adapticai/engine`): switch the Alpaca
+credential read from selecting `AlpacaAccount.APIKey` / `APISecret` to calling
+`alpacaAccountCredentials(accountId)`. Deploy the engine, and confirm via the
+counter that all credential reads now flow through the new query and that trading
+is unaffected. **The old fields still exist at this point** — the engine can be
+rolled back safely.
+
+### (d) Excise the credential fields (separate PR)
+
+Only after (c) is deployed and verified in production:
+
+1. Add `GQL.SKIP=true` to `AlpacaAccount.APIKey` and `AlpacaAccount.APISecret` in
+   `backend-legacy/prisma/schema.prisma` (do **not** delete the columns — the
+   engine still reads them from Postgres via the server-only resolver's Prisma
+   `select`; `GQL.SKIP` only removes them from the GraphQL selection set).
+2. Regenerate (`npm run generate`), rebuild, update selection-set strings,
+   publish the package on the `stable-release` / `0.0.x` lineage.
+3. Consume the new version in the engine and confirm the fields are gone from the
+   GraphQL surface while trading continues via `alpacaAccountCredentials`.
+4. **Rotate the Alpaca API keys** after excision: any key that was ever
+   selectable as a plaintext GraphQL field should be treated as potentially
+   exposed and rotated. Do this per account, out of market hours.
+
+> OAuth-linked broker tokens on `LinkedProvider` (`accessToken` / `refreshToken`)
+> follow the identical server-only-resolver → migrate → excise → rotate pattern
+> in their own change set; they are out of scope for the `AlpacaAccount`
+> credential resolver.
+
+### (e) Flip the enforce flags — one at a time, off shadow evidence
+
+Only once (a)–(d) are complete and the shadow counters are clean:
+
+1. Flip **one** flag at a time, never together:
+   - `CORTEX_AUTHCHECKER_ENFORCE=true`, or
+   - `TENANCY_SCOPING_MODE=enforce`, or
+   - `CORTEX_RATE_LIMIT_ENFORCE=true`.
+2. After each flip, watch error rates and the corresponding would-deny/would-block
+   counter (now denials/blocks) for a full window before the next flip.
+3. **Never flip an enforce flag right before or during a US equities market
+   open.** Choose a low-risk window with on-call present and a tested rollback
+   (each flag reverts to shadow by unsetting the env var — no deploy required).
+
+---
+
+## Rollback
+
+Every guard reverts to inert by unsetting its env var (authChecker, rate limiter)
+or setting `TENANCY_SCOPING_MODE=shadow`; no code deploy is needed. The credential
+resolver is additive and inert until the engine calls it, and the field excision
+(d) is a separate PR that can be reverted independently — but note that once keys
+are rotated in (d.4), a rollback of the engine must use the rotated keys.
+
+## Invariants (do not violate)
+
+- Credential resolver + engine migration (c) BEFORE field excision (d).
+- Shadow validation (a) BEFORE any enforce flip (e).
+- One enforce flag at a time; never immediately before market open.
+- Rotate Alpaca keys after excision (d.4).

--- a/src/resolvers/custom/AlpacaAccountCredentials.ts
+++ b/src/resolvers/custom/AlpacaAccountCredentials.ts
@@ -1,0 +1,53 @@
+import * as TypeGraphQL from 'type-graphql';
+
+/**
+ * Server-only credential material for a single {@link AlpacaAccount}.
+ *
+ * CORTEX-P0-001 (phase-2 readiness). This object type exists so that the engine
+ * can eventually fetch Alpaca API credentials through a dedicated,
+ * server-principal-gated query ({@link AlpacaAccountCredentialsResolver}) rather
+ * than reading the ordinary `AlpacaAccount.APIKey` / `APISecret` fields that any
+ * authenticated caller can currently select. It is the migration target that
+ * MUST exist before those ordinary fields can be excised from the schema.
+ *
+ * Scope note: the fields returned here mirror exactly the credential columns the
+ * engine reads off `AlpacaAccount` (`APIKey`, `APISecret`, plus the `type`
+ * discriminator that selects the Alpaca base URL). OAuth-linked broker tokens
+ * live on the separate `LinkedProvider` model and follow the same
+ * server-only-resolver → excise pattern in a later, independent step (see the
+ * enablement doc); they are intentionally out of scope for this object type so
+ * it does not reference columns `AlpacaAccount` does not own.
+ *
+ * This type is NEVER exposed on a user-facing relation. It is returned only by
+ * the `alpacaAccountCredentials` query, and only to a `server` principal. It is
+ * intentionally not registered as a Prisma relation and carries no `@Authorized`
+ * decorator — the resolver enforces the server-principal gate directly and fails
+ * closed, independent of the (still shadow-mode) CORTEX authChecker.
+ */
+@TypeGraphQL.ObjectType('AlpacaAccountCredentials', {})
+export class AlpacaAccountCredentials {
+  @TypeGraphQL.Field((_type) => String, {
+    nullable: false,
+    description: 'Identifier of the AlpacaAccount these credentials belong to.',
+  })
+  accountId!: string;
+
+  @TypeGraphQL.Field((_type) => String, {
+    nullable: false,
+    description:
+      'Account type discriminator (PAPER or LIVE) — selects the Alpaca base URL.',
+  })
+  type!: string;
+
+  @TypeGraphQL.Field((_type) => String, {
+    nullable: false,
+    description: 'Alpaca API key used to authenticate broker requests.',
+  })
+  APIKey!: string;
+
+  @TypeGraphQL.Field((_type) => String, {
+    nullable: false,
+    description: 'Alpaca API secret used to authenticate broker requests.',
+  })
+  APISecret!: string;
+}

--- a/src/resolvers/custom/AlpacaAccountCredentialsResolver.ts
+++ b/src/resolvers/custom/AlpacaAccountCredentialsResolver.ts
@@ -1,0 +1,153 @@
+import * as TypeGraphQL from 'type-graphql';
+import type { PrismaClient } from '@prisma/client';
+import { GraphQLError } from 'graphql';
+import { Counter } from 'prom-client';
+import { AlpacaAccountCredentials } from './AlpacaAccountCredentials';
+import type { BackendPrincipal } from '../../auth/token-verifier';
+import { metricsRegistry } from '../../config/metrics';
+import { logger } from '../../utils/logger';
+
+/**
+ * GraphQL resolver context consumed by {@link AlpacaAccountCredentialsResolver}.
+ *
+ * `principal` is the verified {@link BackendPrincipal} attached to the context in
+ * `server.ts` (`null`/`undefined` for an unauthenticated caller). `prisma` is the
+ * shared global client. This is the same context shape every custom resolver and
+ * the tenancy-scoping / authChecker middleware read.
+ */
+export interface AlpacaAccountCredentialsContext {
+  prisma: PrismaClient;
+  principal?: BackendPrincipal | null;
+}
+
+/**
+ * Outcome label for {@link alpacaCredentialAccessTotal}. `granted` is emitted for
+ * a successful server-principal read; `denied_non_server` for any non-server (or
+ * unauthenticated) caller that is rejected; `not_found` when the server principal
+ * requested credentials for an account id that does not exist.
+ */
+type CredentialAccessOutcome = 'granted' | 'denied_non_server' | 'not_found';
+
+/**
+ * Counts calls to the server-only `alpacaAccountCredentials` query by outcome.
+ *
+ * This is the observability signal that proves, once the engine migrates onto
+ * this path, that credential reads originate ONLY from the server principal — any
+ * `denied_non_server` sample indicates a misdirected or hostile caller reaching
+ * the credential surface. It carries no account id or secret material, only the
+ * discriminated outcome.
+ */
+export const alpacaCredentialAccessTotal = new Counter({
+  name: 'cortex_alpaca_credential_access_total',
+  help: 'Calls to the server-only alpacaAccountCredentials query, by outcome',
+  labelNames: ['outcome'] as const,
+  registers: [metricsRegistry],
+});
+
+/**
+ * Whether the given principal is the trusted server-to-server caller. Mirrors the
+ * `server`-kind bypass in {@link cortexAuthChecker} and the tenancy-scoping
+ * middleware: only `{ kind: 'server' }` — established by an exact
+ * `SERVER_AUTH_TOKEN` match in {@link verifyBackendToken} — is a server principal.
+ *
+ * @param principal - The verified principal, or `null`/`undefined` when the caller
+ *   presented no (or an unverifiable) token.
+ * @returns `true` only for a `server`-kind principal.
+ */
+export function isServerPrincipal(
+  principal: BackendPrincipal | null | undefined
+): principal is { kind: 'server' } {
+  return principal?.kind === 'server';
+}
+
+/**
+ * CORTEX-P0-001 (phase-2 readiness) — server-only Alpaca credential resolver.
+ *
+ * Exposes a single `alpacaAccountCredentials(accountId)` query that returns the
+ * Alpaca API key/secret for an account ONLY to the engine's `server` principal.
+ * This is the dedicated, principal-gated fetch path the engine will switch to;
+ * once it does, the ordinary `AlpacaAccount.APIKey` / `APISecret` fields become
+ * excisable (GQL.SKIP + regenerate) in a separate, later PR. This resolver does
+ * NOT remove or alter those existing fields, and the engine is NOT wired to this
+ * query here — both are deliberately deferred to their own change sets.
+ *
+ * SECURITY CONTRACT — the gate is enforced in-resolver and fails CLOSED,
+ * independent of the (still shadow-mode, default-off) CORTEX authChecker: a
+ * non-server or unauthenticated caller receives a `FORBIDDEN` error and NEVER any
+ * credential bytes. Because the gate does not rely on an `@Authorized()`
+ * decorator, it is active the moment this resolver is registered — it is not
+ * itself gated behind any enforcement flag.
+ */
+@TypeGraphQL.Resolver((_of) => AlpacaAccountCredentials)
+export class AlpacaAccountCredentialsResolver {
+  /**
+   * Fetch the Alpaca API credentials for a single account. Server-principal only.
+   *
+   * @param accountId - The `AlpacaAccount.id` whose credentials are requested.
+   * @param ctx - Resolver context carrying the verified principal and Prisma client.
+   * @returns The account's credential material, or `null` when no account with
+   *   that id exists.
+   * @throws {GraphQLError} `FORBIDDEN` when the caller is not the server principal.
+   */
+  @TypeGraphQL.Query((_returns) => AlpacaAccountCredentials, {
+    nullable: true,
+    description:
+      'Server-only: resolve Alpaca API credentials for an account. Requires the server principal; all other callers are rejected with FORBIDDEN.',
+  })
+  async alpacaAccountCredentials(
+    @TypeGraphQL.Arg('accountId', (_type) => String) accountId: string,
+    @TypeGraphQL.Ctx() ctx: AlpacaAccountCredentialsContext
+  ): Promise<AlpacaAccountCredentials | null> {
+    const principal = ctx.principal ?? null;
+
+    if (!isServerPrincipal(principal)) {
+      alpacaCredentialAccessTotal.inc({ outcome: 'denied_non_server' });
+      logger.warn(
+        '[cortex-credentials] denied non-server access to alpacaAccountCredentials',
+        {
+          principalKind: principal?.kind ?? 'none',
+        }
+      );
+      throw new GraphQLError(
+        'alpacaAccountCredentials is restricted to the server principal',
+        {
+          extensions: {
+            code: 'FORBIDDEN',
+            http: { status: 403 },
+          },
+        }
+      );
+    }
+
+    const account = await ctx.prisma.alpacaAccount.findUnique({
+      where: { id: accountId },
+      select: {
+        id: true,
+        type: true,
+        APIKey: true,
+        APISecret: true,
+      },
+    });
+
+    if (!account) {
+      alpacaCredentialAccessTotal.inc({ outcome: 'not_found' });
+      logger.warn(
+        '[cortex-credentials] server requested credentials for unknown account',
+        { accountId }
+      );
+      return null;
+    }
+
+    alpacaCredentialAccessTotal.inc({ outcome: 'granted' });
+    logger.info('[cortex-credentials] server credential read', {
+      accountId: account.id,
+    });
+
+    return {
+      accountId: account.id,
+      type: account.type,
+      APIKey: account.APIKey,
+      APISecret: account.APISecret,
+    };
+  }
+}

--- a/src/resolvers/custom/__tests__/AlpacaAccountCredentialsResolver.test.ts
+++ b/src/resolvers/custom/__tests__/AlpacaAccountCredentialsResolver.test.ts
@@ -1,0 +1,151 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GraphQLError } from 'graphql';
+import type { PrismaClient } from '@prisma/client';
+import {
+  AlpacaAccountCredentialsResolver,
+  isServerPrincipal,
+  alpacaCredentialAccessTotal,
+  type AlpacaAccountCredentialsContext,
+} from '../AlpacaAccountCredentialsResolver';
+import type { BackendPrincipal } from '../../../auth/token-verifier';
+
+/**
+ * CORTEX-P0-001 (phase-2 readiness) unit tests for the server-only Alpaca
+ * credential resolver.
+ *
+ * The security-critical property is the server-principal gate: the credential
+ * material MUST be returned ONLY to a `{ kind: 'server' }` principal, and EVERY
+ * other caller (user, admin, unauthenticated) MUST be rejected with a FORBIDDEN
+ * error before Prisma is ever touched. These properties are the precondition for
+ * migrating the engine onto this path and subsequently excising the ordinary
+ * APIKey/APISecret fields, so they are proven in isolation here.
+ */
+
+const ACCOUNT_ID = '11111111-1111-1111-1111-111111111111';
+const USER_SUB = '99999999-9999-9999-9999-999999999999';
+
+const SERVER_PRINCIPAL: BackendPrincipal = { kind: 'server' };
+const USER_PRINCIPAL: BackendPrincipal = {
+  kind: 'user',
+  sub: USER_SUB,
+  roles: ['user'],
+};
+const ADMIN_PRINCIPAL: BackendPrincipal = {
+  kind: 'admin',
+  sub: USER_SUB,
+  roles: ['admin'],
+};
+
+interface AlpacaAccountRow {
+  id: string;
+  type: string;
+  APIKey: string;
+  APISecret: string;
+}
+
+/**
+ * Build a resolver context with a stubbed Prisma client whose
+ * `alpacaAccount.findUnique` resolves to the supplied row (or `null`). The mock
+ * is returned so tests can assert whether the DB was reached.
+ */
+function buildContext(
+  principal: BackendPrincipal | null,
+  row: AlpacaAccountRow | null
+): {
+  ctx: AlpacaAccountCredentialsContext;
+  findUnique: ReturnType<typeof vi.fn>;
+} {
+  const findUnique = vi.fn().mockResolvedValue(row);
+  const prisma = {
+    alpacaAccount: { findUnique },
+  } as unknown as PrismaClient;
+  return { ctx: { prisma, principal }, findUnique };
+}
+
+/** Read the current value of the access counter for a given outcome label. */
+async function accessCount(outcome: string): Promise<number> {
+  const metric = await alpacaCredentialAccessTotal.get();
+  const sample = metric.values.find((v) => v.labels.outcome === outcome);
+  return sample?.value ?? 0;
+}
+
+describe('isServerPrincipal', () => {
+  it('is true only for a server-kind principal', () => {
+    expect(isServerPrincipal(SERVER_PRINCIPAL)).toBe(true);
+    expect(isServerPrincipal(USER_PRINCIPAL)).toBe(false);
+    expect(isServerPrincipal(ADMIN_PRINCIPAL)).toBe(false);
+    expect(isServerPrincipal(null)).toBe(false);
+    expect(isServerPrincipal(undefined)).toBe(false);
+  });
+});
+
+describe('AlpacaAccountCredentialsResolver.alpacaAccountCredentials', () => {
+  let resolver: AlpacaAccountCredentialsResolver;
+
+  beforeEach(() => {
+    resolver = new AlpacaAccountCredentialsResolver();
+  });
+
+  it('returns credentials for a server principal', async () => {
+    const row: AlpacaAccountRow = {
+      id: ACCOUNT_ID,
+      type: 'LIVE',
+      APIKey: 'AK-live-key',
+      APISecret: 'AK-live-secret',
+    };
+    const before = await accessCount('granted');
+    const { ctx, findUnique } = buildContext(SERVER_PRINCIPAL, row);
+
+    const result = await resolver.alpacaAccountCredentials(ACCOUNT_ID, ctx);
+
+    expect(result).toEqual({
+      accountId: ACCOUNT_ID,
+      type: 'LIVE',
+      APIKey: 'AK-live-key',
+      APISecret: 'AK-live-secret',
+    });
+    expect(findUnique).toHaveBeenCalledOnce();
+    expect(await accessCount('granted')).toBe(before + 1);
+  });
+
+  it('returns null when the server principal requests an unknown account', async () => {
+    const before = await accessCount('not_found');
+    const { ctx, findUnique } = buildContext(SERVER_PRINCIPAL, null);
+
+    const result = await resolver.alpacaAccountCredentials(ACCOUNT_ID, ctx);
+
+    expect(result).toBeNull();
+    expect(findUnique).toHaveBeenCalledOnce();
+    expect(await accessCount('not_found')).toBe(before + 1);
+  });
+
+  it('rejects a user principal with FORBIDDEN and never touches Prisma', async () => {
+    const before = await accessCount('denied_non_server');
+    const { ctx, findUnique } = buildContext(USER_PRINCIPAL, null);
+
+    await expect(
+      resolver.alpacaAccountCredentials(ACCOUNT_ID, ctx)
+    ).rejects.toThrowError(GraphQLError);
+    expect(findUnique).not.toHaveBeenCalled();
+    expect(await accessCount('denied_non_server')).toBe(before + 1);
+  });
+
+  it('rejects an admin principal (admin is not server)', async () => {
+    const { ctx, findUnique } = buildContext(ADMIN_PRINCIPAL, null);
+
+    await expect(
+      resolver.alpacaAccountCredentials(ACCOUNT_ID, ctx)
+    ).rejects.toMatchObject({ extensions: { code: 'FORBIDDEN' } });
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unauthenticated (null principal) caller', async () => {
+    const { ctx, findUnique } = buildContext(null, null);
+
+    await expect(
+      resolver.alpacaAccountCredentials(ACCOUNT_ID, ctx)
+    ).rejects.toMatchObject({ extensions: { code: 'FORBIDDEN' } });
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/resolvers/custom/index.ts
+++ b/src/resolvers/custom/index.ts
@@ -6,3 +6,5 @@
 
 export { OptionsGreeksHistoryCustomResolver } from './OptionsGreeksHistoryCustomResolver';
 export { OptionsGreeksHistorySystemSummary } from './OptionsGreeksHistorySystemSummary';
+export { AlpacaAccountCredentialsResolver } from './AlpacaAccountCredentialsResolver';
+export { AlpacaAccountCredentials } from './AlpacaAccountCredentials';

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,10 @@ import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHt
 import { buildSchema } from 'type-graphql';
 import { GraphQLError } from 'graphql';
 import { resolvers } from './generated/typegraphql-prisma';
-import { OptionsGreeksHistoryCustomResolver } from './resolvers/custom';
+import {
+  OptionsGreeksHistoryCustomResolver,
+  AlpacaAccountCredentialsResolver,
+} from './resolvers/custom';
 import { createServer } from 'http';
 import cors from 'cors';
 import bodyParser from 'body-parser';
@@ -116,7 +119,16 @@ const startServer = async () => {
   initMetrics();
 
   const schema = await buildSchema({
-    resolvers: [...resolvers, OptionsGreeksHistoryCustomResolver],
+    resolvers: [
+      ...resolvers,
+      OptionsGreeksHistoryCustomResolver,
+      // CORTEX-P0-001 (phase-2 readiness): additive, server-principal-gated
+      // `alpacaAccountCredentials` query. Inert for the live engine (not wired
+      // to it yet) and removes/alters no existing field; it is the migration
+      // target that must exist before the ordinary APIKey/APISecret fields can
+      // be excised in a later PR. See docs/security/cortex-p0-001-enablement.md.
+      AlpacaAccountCredentialsResolver,
+    ],
     validate: false,
     // Row-level tenancy scoping (SP2-G7 / SOC2). Applies ONLY to user-scoped
     // principals on the tenancy + notification models; service/admin principals


### PR DESCRIPTION
**Review-only — do not merge without validating the enablement plan.** Phase-2 readiness for CORTEX-P0-001: additive, inert, **no enforcement flip / no schema excision / no codegen**.

### What it adds
- **`alpacaAccountCredentials(accountId)` — server-only credential resolver.** Returns `AlpacaAccount` `APIKey`/`APISecret` **only** when `ctx.principal.kind === 'server'` (the engine's server principal); `user`/`admin`/`null` are rejected `FORBIDDEN` **before Prisma is touched** (fail-closed). Gate is active on registration (not behind a shadow flag). **This is the prerequisite** — once the engine migrates to it, the ordinary `APIKey`/`APISecret` fields can be GQL.SKIP-excised (a later PR) without breaking the engine's credential reads. Existing fields untouched. Metric: `cortex_alpaca_credential_access_total{outcome}`.
- **`docs/security/cortex-p0-001-enablement.md`** — the ordered, validated enablement sequence + hard invariants (credential-resolver + engine migration *before* excision; shadow validation *before* any enforce flip; never right before market open; rotate keys after excision) + rollback (unset the env var, no deploy).

### Sequencing (why this is only "ready")
1. Run phase-1 shadow (**PR #11**, published in `@stable` 0.0.997) in prod → watch `cortex_authchecker_would_deny_total` / `cortex_rate_limit_would_block_total` for a full window, confirm zero legitimate would-denies.
2. Migrate the **engine** to `alpacaAccountCredentials` (separate engine PR).
3. **Then** excise the credential fields (separate PR) + rotate keys.
4. Flip `CORTEX_AUTHCHECKER_ENFORCE` / tenancy=enforce / rate-limit enforce **one at a time** off the shadow evidence.

**6/6 gating tests pass.** The 2 `server.ts` tsc errors are pre-existing (the intentionally-un-generated `generated/` dir); resolves under CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
